### PR TITLE
Removed 1 unnecessary stubbing in ReopeningInterruptibleChannelTest.java

### DIFF
--- a/src/test/java/org/terracotta/offheapstore/util/ReopeningInterruptibleChannelTest.java
+++ b/src/test/java/org/terracotta/offheapstore/util/ReopeningInterruptibleChannelTest.java
@@ -143,7 +143,6 @@ public class ReopeningInterruptibleChannelTest {
   @Test
   public void testOpenDespiteDelegateClosure() throws IOException {
     SimpleInterruptibleChannel delegate = mock(SimpleInterruptibleChannel.class);
-    when(delegate.operation()).thenThrow(ClosedChannelException.class);
     ReopeningInterruptibleChannel<SimpleInterruptibleChannel> reopeningChannel = ReopeningInterruptibleChannel.create(() -> delegate);
 
     assertThat(reopeningChannel.isOpen(), is(true));


### PR DESCRIPTION
In our analysis of the project, we observed that 
1) 1 unnecessary stubbing is created but never executed in the test `ReopeningInterruptibleChannelTest.testOpenDespiteDelegateClosure`.

Unnecessary stubbings are stubbed method calls that were never realized during test execution. Mockito recommends to remove unnecessary stubbings (https://www.javadoc.io/doc/org.mockito/mockito-core/latest/org/mockito/exceptions/misusing/UnnecessaryStubbingException.html). We propose below a solution to remove the unnecessary stubbings.